### PR TITLE
Scrape by pre-determined intervals and add randomizing HTTP headers

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,6 +10,6 @@
 <!--- These are suggested things you could add, but what you add will be dependent on your repository's standards. --->
 - [ ] The code runs successfully.
 
-```console
+```shell
 HERE IS SOME COMMAND LINE OUTPUT
 ```

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # Misc.
+/incident_scraper/data
 **.ipynb
 
 # IDE files and misc.

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,1 @@
-/incident-scraper/ @michplunkett
-/test/ @michplunkett
+/incident-scraper/ @michplunkett @FedericoDM

--- a/incident_scraper/__main__.py
+++ b/incident_scraper/__main__.py
@@ -3,6 +3,8 @@ import argparse
 
 from click import IntRange
 
+from incident_scraper.scraper.ucpd_scraper import UCPDScraper
+
 
 def main():
     """Run the UCPD Incident Scraper."""
@@ -21,10 +23,20 @@ def main():
 
     args = parser.parse_args()
 
+    scraper = UCPDScraper()
+
+    incidents: dict
     if args.command == "days-back":
-        print(f"Gonna go {args.days} days back.")
+        if days_back == 3:
+            incidents = scraper.scrape_last_three_days()
+        elif days_back == 5:
+            incidents = scraper.scrape_last_five_days()
+        elif days_back == 10:
+            incidents = scraper.scrape_last_ten_days()
     elif args.command == "seed":
-        print("Gonna get ALL the incidents")
+        incidents = scraper.scrape_from_beginning_2023()
+
+    print(f"We scraped this many incidents: {len(incidents)}")
 
 
 if __name__ == "__main__":

--- a/incident_scraper/__main__.py
+++ b/incident_scraper/__main__.py
@@ -27,11 +27,11 @@ def main():
 
     incidents: dict
     if args.command == "days-back":
-        if days_back == 3:
+        if args.days == 3:
             incidents = scraper.scrape_last_three_days()
-        elif days_back == 5:
+        elif args.days == 5:
             incidents = scraper.scrape_last_five_days()
-        elif days_back == 10:
+        elif args.days == 10:
             incidents = scraper.scrape_last_ten_days()
     elif args.command == "seed":
         incidents = scraper.scrape_from_beginning_2023()

--- a/incident_scraper/scraper/headers.py
+++ b/incident_scraper/scraper/headers.py
@@ -17,7 +17,9 @@ class Headers:
             os.getcwd().replace("\\", "/")
             + "/incident_scraper/data/http_headers.json"
         )
-        self.list_of_headers = json.load(path)
+        print(path)
+        with open(path, "r") as json_file:
+            self.list_of_headers = json.load(json_file)
 
     def get_random_header(self):
         """Use random number generator to get random header from list."""

--- a/incident_scraper/scraper/headers.py
+++ b/incident_scraper/scraper/headers.py
@@ -1,0 +1,26 @@
+"""Contains the headers class."""
+import json
+import os
+import random
+
+
+class Headers:
+    """Class that contains all headers in external header file."""
+
+    def __init__(self):
+        self.list_of_headers = []
+        self._load_headers_file()
+
+    def _load_headers_file(self):
+        """Load the list of headers."""
+        path = (
+            os.getcwd().replace("\\", "/")
+            + "/incident_scraper/data/http_headers.json"
+        )
+        self.list_of_headers = json.load(path)
+
+    def get_random_header(self):
+        """Use random number generator to get random header from list."""
+        return self.list_of_headers[
+            random.randint(0, len(self.list_of_headers))
+        ]

--- a/incident_scraper/scraper/headers.py
+++ b/incident_scraper/scraper/headers.py
@@ -17,7 +17,6 @@ class Headers:
             os.getcwd().replace("\\", "/")
             + "/incident_scraper/data/http_headers.json"
         )
-        print(path)
         with open(path, "r") as json_file:
             self.list_of_headers = json.load(json_file)
 

--- a/incident_scraper/scraper/ucpd_scraper.py
+++ b/incident_scraper/scraper/ucpd_scraper.py
@@ -118,8 +118,3 @@ class UCPDScraper:
             incidents.update(rev_dict)
             offset += 5
         return str(incidents)
-
-
-if __name__ == "__main__":
-    scraper = UCPDScraper()
-    scraper.scrape_last_three_days()

--- a/incident_scraper/scraper/ucpd_scraper.py
+++ b/incident_scraper/scraper/ucpd_scraper.py
@@ -106,7 +106,7 @@ class UCPDScraper:
         # Track page number, as offset will take you back to zero
         pages = response.cssselect("span.page-link")
         page_numbers = pages[FIRST_INDEX].text.split(" / ")
-        return incident_dict, page_numbers[0] == page_numbers[1]
+        return incident_dict, page_numbers[0].strip() == page_numbers[1].strip()
 
     def _get_incidents(self, new_url: str):
         """Get all incidents for a given URL."""

--- a/incident_scraper/scraper/ucpd_scraper.py
+++ b/incident_scraper/scraper/ucpd_scraper.py
@@ -22,7 +22,7 @@ class UCPDScraper:
     def __init__(self, request_delay=0.2):
         self.request_delay = request_delay
         self.today = datetime.now(self.TZ).date()
-        self.str_today = self.today.strftime("%m/%d/%Y")
+        self.str_today = self.today.strftime(self.UCPD_MDY_DATE_FORMAT)
         self.base_url = self._construct_url(0)
         self.headers = HEADERS.copy()
         self.user_agent_rotator = Headers()

--- a/incident_scraper/scraper/ucpd_scraper.py
+++ b/incident_scraper/scraper/ucpd_scraper.py
@@ -24,7 +24,7 @@ class UCPDScraper:
         self.today = datetime.now(self.TZ).date()
         self.str_today = self.today.strftime("%m/%d/%Y")
         self.base_url = self._construct_url(0)
-        self.headers = HEADERS
+        self.headers = HEADERS.copy()
         self.user_agent_rotator = Headers()
 
     def scrape_from_beginning_2023(self):

--- a/incident_scraper/scraper/ucpd_scraper.py
+++ b/incident_scraper/scraper/ucpd_scraper.py
@@ -28,8 +28,16 @@ class UCPDScraper:
         """Scrape and parse all tables from January 1, 2023 to today."""
         pass
 
+    def scrape_last_three_days(self):
+        """Scrape and parse all tables from three days ago to today."""
+        pass
+
     def scrape_last_five_days(self):
         """Scrape and parse all tables from five days ago to today."""
+        pass
+
+    def scrape_last_ten_days(self):
+        """Scrape and parse all tables from ten days ago to today."""
         pass
 
     def _get_previous_day_epoch(self, num_days=1):

--- a/incident_scraper/scraper/ucpd_scraper.py
+++ b/incident_scraper/scraper/ucpd_scraper.py
@@ -22,6 +22,7 @@ class UCPDScraper:
     def __init__(self, request_delay=0.2):
         self.request_delay = request_delay
         self.today = datetime.now(self.TZ).date()
+        self.str_today = self.today.strftime("%m/%d/%Y")
         self.base_url = self._construct_url()
 
     def scrape_from_beginning_2023(self):

--- a/incident_scraper/scraper/ucpd_scraper.py
+++ b/incident_scraper/scraper/ucpd_scraper.py
@@ -23,7 +23,6 @@ class UCPDScraper:
         self.request_delay = request_delay
         self.today = datetime.now(self.TZ).date()
         self.today_str = self.today.strftime(self.UCPD_MDY_DATE_FORMAT)
-        self.base_url = self._construct_url(0)
         self.headers = HEADERS.copy()
         self.user_agent_rotator = Headers()
 

--- a/incident_scraper/scraper/ucpd_scraper.py
+++ b/incident_scraper/scraper/ucpd_scraper.py
@@ -30,35 +30,22 @@ class UCPDScraper:
     def scrape_from_beginning_2023(self):
         """Scrape and parse all tables from January 1, 2023 to today."""
         new_url = self._construct_url(0, year_beginning=True)
-        pass
+        self.get_all_tables(new_url)
 
     def scrape_last_three_days(self):
         """Scrape and parse all tables from three days ago to today."""
         new_url = self._construct_url(3, year_beginning=False)
-        pass
+        self.get_all_tables(new_url)
 
     def scrape_last_five_days(self):
         """Scrape and parse all tables from five days ago to today."""
         new_url = self._construct_url(5, year_beginning=False)
-        pass
+        self.get_all_tables(new_url)
 
     def scrape_last_ten_days(self):
         """Scrape and parse all tables from ten days ago to today."""
         new_url = self._construct_url(10, year_beginning=False)
-        pass
-
-    def _get_previous_day_epoch(self, num_days=1):
-        """Return epoch time of a previous day at midnight.
-
-        Given the number of days to subtract from the current date, return the epoch
-        time of that day at midnight.
-        """
-        # Subtract one day from the current date
-        previous_day = self.today - timedelta(days=num_days)
-        previous_day_midnight = self.TZ.localize(
-            datetime.combine(previous_day, dt_time()), is_dst=None
-        )
-        return int(previous_day_midnight.timestamp())
+        self.get_all_tables(new_url)
 
     def _construct_url(self, num_days, year_beginning=False):
         """
@@ -118,7 +105,7 @@ class UCPDScraper:
         page_numbers = pages[FIRST_INDEX].text.split(" / ")
         return incident_dict, page_numbers[0] == page_numbers[1]
 
-    def get_all_tables(self):
+    def get_all_tables(self, new_url):
         """Go through all queried tables until we offset back to the first table."""
         at_last_page = False
         incidents = dict()
@@ -126,9 +113,7 @@ class UCPDScraper:
 
         # Loop until function arrives at last page
         while not at_last_page:
-            rev_dict, at_last_page = self._get_table(
-                self.base_url + str(offset)
-            )
+            rev_dict, at_last_page = self._get_table(new_url + str(offset))
             incidents.update(rev_dict)
             offset += 5
         return str(incidents)

--- a/incident_scraper/scraper/ucpd_scraper.py
+++ b/incident_scraper/scraper/ucpd_scraper.py
@@ -8,7 +8,7 @@ import lxml.html
 import pytz
 import requests
 
-from incident_scraper.utils.constants import TIMEZONE_CHICAGO
+from incident_scraper.utils.constants import TIMEZONE_CHICAGO, HEADERS
 
 
 class UCPDScraper:
@@ -18,6 +18,7 @@ class UCPDScraper:
         "https://incidentreports.uchicago.edu/incidentReportArchive.php"
     )
     TZ = pytz.timezone(TIMEZONE_CHICAGO)
+    HEADERS = HEADERS
 
     def __init__(self, request_delay=0.2):
         self.request_delay = request_delay
@@ -89,7 +90,7 @@ class UCPDScraper:
 
         print(f"Fetching {url}")
         time.sleep(self.request_delay)
-        r = requests.get(url)
+        r = requests.get(url, headers=self.HEADERS)
         response = lxml.html.fromstring(r.content)
         container = response.cssselect("thead")
         categories = container[FIRST_INDEX].cssselect("th")

--- a/incident_scraper/scraper/ucpd_scraper.py
+++ b/incident_scraper/scraper/ucpd_scraper.py
@@ -8,7 +8,7 @@ import lxml.html
 import pytz
 import requests
 
-from incident_scraper.utils.constants import TIMEZONE_CHICAGO, HEADERS
+from incident_scraper.utils.constants import HEADERS, TIMEZONE_CHICAGO
 
 
 class UCPDScraper:

--- a/incident_scraper/scraper/ucpd_scraper.py
+++ b/incident_scraper/scraper/ucpd_scraper.py
@@ -22,13 +22,13 @@ class UCPDScraper:
     def __init__(self, request_delay=0.2):
         self.request_delay = request_delay
         self.today = datetime.now(self.TZ).date()
-        self.str_today = self.today.strftime(self.UCPD_MDY_DATE_FORMAT)
+        self.today_str = self.today.strftime(self.UCPD_MDY_DATE_FORMAT)
         self.base_url = self._construct_url(0)
         self.headers = HEADERS.copy()
         self.user_agent_rotator = Headers()
 
     def scrape_from_beginning_2023(self):
-        """Scrape and parse all tables from January 1, 2023 to today."""
+        """Scrape and parse all tables from January 1, 2023, to today."""
         new_url = self._construct_url(year_beginning=True)
         self._get_incidents(new_url)
 
@@ -54,23 +54,20 @@ class UCPDScraper:
         Constructs the URL to scrape from by getting the epochs of the present day and
         the first day of the current year.
         """
-        if not year_beginning:
-            previous_datetime = self.today - timedelta(days=num_days)
-            previous_date_str = previous_datetime.strftime(
-                self.UCPD_MDY_DATE_FORMAT
-            )
-        else:
-            # Get first day of the year in %m/%d/%Y format
-            year_beginning = datetime(self.today.year, 1, 1).date()
-            previous_date_str = year_beginning.strftime(
-                self.UCPD_MDY_DATE_FORMAT
-            )
+        previous_datetime = (
+            datetime(self.today.year, 1, 1).date()
+            if year_beginning
+            else self.today - timedelta(days=num_days)
+        )
+        previous_date_str = previous_datetime.strftime(
+            self.UCPD_MDY_DATE_FORMAT
+        )
 
         print(f"Today's date: {self.today}")
         print("Constructing URL...")
         return (
             f"{self.BASE_UCPD_URL}?startDate={previous_date_str}&endDate="
-            f"{self.str_today}&offset="
+            f"{self.today_str}&offset="
         )
 
     def _get_table(self, url: str):
@@ -78,7 +75,7 @@ class UCPDScraper:
         Get the table information from that UCPD incident page.
 
         Scrapes the table from the given url and returns a dictionary and a boolean
-        stating if it scraped the last page..
+        stating if it scraped the last page.
         """
         FIRST_INDEX = 0
         INCIDENT_INDEX = 6

--- a/incident_scraper/scraper/ucpd_scraper.py
+++ b/incident_scraper/scraper/ucpd_scraper.py
@@ -30,22 +30,22 @@ class UCPDScraper:
     def scrape_from_beginning_2023(self):
         """Scrape and parse all tables from January 1, 2023, to today."""
         new_url = self._construct_url(year_beginning=True)
-        self._get_incidents(new_url)
+        return self._get_incidents(new_url)
 
     def scrape_last_three_days(self):
         """Scrape and parse all tables from three days ago to today."""
         new_url = self._construct_url(num_days=3)
-        self._get_incidents(new_url)
+        return self._get_incidents(new_url)
 
     def scrape_last_five_days(self):
         """Scrape and parse all tables from five days ago to today."""
         new_url = self._construct_url(num_days=5)
-        self._get_incidents(new_url)
+        return self._get_incidents(new_url)
 
     def scrape_last_ten_days(self):
         """Scrape and parse all tables from ten days ago to today."""
         new_url = self._construct_url(num_days=10)
-        self._get_incidents(new_url)
+        return self._get_incidents(new_url)
 
     def _construct_url(self, num_days: int = 0, year_beginning: bool = False):
         """

--- a/incident_scraper/scraper/ucpd_scraper.py
+++ b/incident_scraper/scraper/ucpd_scraper.py
@@ -56,26 +56,26 @@ class UCPDScraper:
         )
         return int(previous_day_midnight.timestamp())
 
-    def _construct_url(self):
+    def _construct_url(self, num_days, year_beginning=False):
         """
         Construct the url to scrape from.
 
         Constructs the url to scrape from by getting the epochs of the present day and
         the first day of the current year.
         """
-        current_day = self._get_previous_day_epoch(num_days=0)
-        # Difference in number of days between today and the first day of the year
-        # This is used to calculate the number of pages to scrape
-        days_since_start = (
-            self.today - datetime(self.today.year, 1, 1).date()
-        ).days
-        first_day_of_year = self._get_previous_day_epoch(days_since_start)
+        if not year_beginning:
+            previous_datetime = self.today - timedelta(days=num_days)
+            previous_date_str = previous_datetime.strftime("%m/%d/%Y")
+        else:
+            # Get first day of the year in %m/%d/%Y format
+            year_beginning = datetime(self.today.year, 1, 1).date()
+            previous_date_str = year_beginning.strftime("%m/%d/%Y")
 
         print(f"Today's date: {self.today}")
         print("Constructing URL...")
         return (
-            f"{self.BASE_UCPD_URL}?startDate={first_day_of_year}&endDate="
-            f"{current_day}&offset="
+            f"{self.BASE_UCPD_URL}?startDate={previous_date_str}&endDate="
+            f"{self.str_today}&offset="
         )
 
     def _get_table(self, url: str):

--- a/incident_scraper/scraper/ucpd_scraper.py
+++ b/incident_scraper/scraper/ucpd_scraper.py
@@ -8,7 +8,8 @@ import lxml.html
 import pytz
 import requests
 
-from incident_scraper.utils.constants import HEADERS, TIMEZONE_CHICAGO
+from incident_scraper.scraper.headers import Headers
+from incident_scraper.utils.constants import TIMEZONE_CHICAGO
 
 
 class UCPDScraper:
@@ -18,13 +19,13 @@ class UCPDScraper:
         "https://incidentreports.uchicago.edu/incidentReportArchive.php"
     )
     TZ = pytz.timezone(TIMEZONE_CHICAGO)
-    HEADERS = HEADERS
 
     def __init__(self, request_delay=0.2):
         self.request_delay = request_delay
         self.today = datetime.now(self.TZ).date()
         self.str_today = self.today.strftime("%m/%d/%Y")
         self.base_url = self._construct_url()
+        self.headers = Headers()
 
     def scrape_from_beginning_2023(self):
         """Scrape and parse all tables from January 1, 2023 to today."""

--- a/incident_scraper/scraper/ucpd_scraper.py
+++ b/incident_scraper/scraper/ucpd_scraper.py
@@ -29,18 +29,22 @@ class UCPDScraper:
 
     def scrape_from_beginning_2023(self):
         """Scrape and parse all tables from January 1, 2023 to today."""
+        new_url = self._construct_url(0, year_beginning=True)
         pass
 
     def scrape_last_three_days(self):
         """Scrape and parse all tables from three days ago to today."""
+        new_url = self._construct_url(3, year_beginning=False)
         pass
 
     def scrape_last_five_days(self):
         """Scrape and parse all tables from five days ago to today."""
+        new_url = self._construct_url(5, year_beginning=False)
         pass
 
     def scrape_last_ten_days(self):
         """Scrape and parse all tables from ten days ago to today."""
+        new_url = self._construct_url(10, year_beginning=False)
         pass
 
     def _get_previous_day_epoch(self, num_days=1):

--- a/incident_scraper/scraper/ucpd_scraper.py
+++ b/incident_scraper/scraper/ucpd_scraper.py
@@ -55,7 +55,7 @@ class UCPDScraper:
         the first day of the current year.
         """
         previous_datetime = (
-            datetime(self.today.year, 1, 1).date()
+            datetime(2023, 1, 1).date()
             if year_beginning
             else self.today - timedelta(days=num_days)
         )

--- a/incident_scraper/scraper/ucpd_scraper.py
+++ b/incident_scraper/scraper/ucpd_scraper.py
@@ -30,22 +30,22 @@ class UCPDScraper:
     def scrape_from_beginning_2023(self):
         """Scrape and parse all tables from January 1, 2023 to today."""
         new_url = self._construct_url(year_beginning=True)
-        self.get_all_tables(new_url)
+        self._get_incidents(new_url)
 
     def scrape_last_three_days(self):
         """Scrape and parse all tables from three days ago to today."""
         new_url = self._construct_url(num_days=3)
-        self.get_all_tables(new_url)
+        self._get_incidents(new_url)
 
     def scrape_last_five_days(self):
         """Scrape and parse all tables from five days ago to today."""
         new_url = self._construct_url(num_days=5)
-        self.get_all_tables(new_url)
+        self._get_incidents(new_url)
 
     def scrape_last_ten_days(self):
         """Scrape and parse all tables from ten days ago to today."""
         new_url = self._construct_url(num_days=10)
-        self.get_all_tables(new_url)
+        self._get_incidents(new_url)
 
     def _construct_url(self, num_days=0, year_beginning=False):
         """
@@ -111,8 +111,8 @@ class UCPDScraper:
         page_numbers = pages[FIRST_INDEX].text.split(" / ")
         return incident_dict, page_numbers[0] == page_numbers[1]
 
-    def get_all_tables(self, new_url: str):
-        """Go through all queried tables until we offset back to the first table."""
+    def _get_incidents(self, new_url: str):
+        """Get all incidents for a given URL."""
         at_last_page = False
         incidents = dict()
         offset = 0

--- a/incident_scraper/scraper/ucpd_scraper.py
+++ b/incident_scraper/scraper/ucpd_scraper.py
@@ -47,7 +47,7 @@ class UCPDScraper:
         new_url = self._construct_url(num_days=10)
         self._get_incidents(new_url)
 
-    def _construct_url(self, num_days=0, year_beginning=False):
+    def _construct_url(self, num_days: int = 0, year_beginning: bool = False):
         """
         Construct the scraping URL.
 
@@ -119,4 +119,4 @@ class UCPDScraper:
             rev_dict, at_last_page = self._get_table(new_url + str(offset))
             incidents.update(rev_dict)
             offset += 5
-        return str(incidents)
+        return incidents

--- a/incident_scraper/scraper/ucpd_scraper.py
+++ b/incident_scraper/scraper/ucpd_scraper.py
@@ -24,6 +24,14 @@ class UCPDScraper:
         self.today = datetime.now(self.TZ).date()
         self.base_url = self._construct_url()
 
+    def scrape_from_beginning_2023(self):
+        """Scrape and parse all tables from January 1, 2023 to today."""
+        pass
+
+    def scrape_last_five_days(self):
+        """Scrape and parse all tables from five days ago to today."""
+        pass
+
     def _get_previous_day_epoch(self, num_days=1):
         """Return epoch time of a previous day at midnight.
 

--- a/incident_scraper/scraper/ucpd_scraper.py
+++ b/incident_scraper/scraper/ucpd_scraper.py
@@ -17,6 +17,7 @@ class UCPDScraper:
         "https://incidentreports.uchicago.edu/incidentReportArchive.php"
     )
     TZ = pytz.timezone(TIMEZONE_CHICAGO)
+    UCPD_MDY_DATE_FORMAT = "%m/%d/%Y"
 
     def __init__(self, request_delay=0.2):
         self.request_delay = request_delay
@@ -28,38 +29,42 @@ class UCPDScraper:
 
     def scrape_from_beginning_2023(self):
         """Scrape and parse all tables from January 1, 2023 to today."""
-        new_url = self._construct_url(0, year_beginning=True)
+        new_url = self._construct_url(year_beginning=True)
         self.get_all_tables(new_url)
 
     def scrape_last_three_days(self):
         """Scrape and parse all tables from three days ago to today."""
-        new_url = self._construct_url(3, year_beginning=False)
+        new_url = self._construct_url(num_days=3)
         self.get_all_tables(new_url)
 
     def scrape_last_five_days(self):
         """Scrape and parse all tables from five days ago to today."""
-        new_url = self._construct_url(5, year_beginning=False)
+        new_url = self._construct_url(num_days=5)
         self.get_all_tables(new_url)
 
     def scrape_last_ten_days(self):
         """Scrape and parse all tables from ten days ago to today."""
-        new_url = self._construct_url(10, year_beginning=False)
+        new_url = self._construct_url(num_days=10)
         self.get_all_tables(new_url)
 
-    def _construct_url(self, num_days, year_beginning=False):
+    def _construct_url(self, num_days=0, year_beginning=False):
         """
-        Construct the url to scrape from.
+        Construct the scraping URL.
 
-        Constructs the url to scrape from by getting the epochs of the present day and
+        Constructs the URL to scrape from by getting the epochs of the present day and
         the first day of the current year.
         """
         if not year_beginning:
             previous_datetime = self.today - timedelta(days=num_days)
-            previous_date_str = previous_datetime.strftime("%m/%d/%Y")
+            previous_date_str = previous_datetime.strftime(
+                self.UCPD_MDY_DATE_FORMAT
+            )
         else:
             # Get first day of the year in %m/%d/%Y format
             year_beginning = datetime(self.today.year, 1, 1).date()
-            previous_date_str = year_beginning.strftime("%m/%d/%Y")
+            previous_date_str = year_beginning.strftime(
+                self.UCPD_MDY_DATE_FORMAT
+            )
 
         print(f"Today's date: {self.today}")
         print("Constructing URL...")
@@ -106,7 +111,7 @@ class UCPDScraper:
         page_numbers = pages[FIRST_INDEX].text.split(" / ")
         return incident_dict, page_numbers[0] == page_numbers[1]
 
-    def get_all_tables(self, new_url):
+    def get_all_tables(self, new_url: str):
         """Go through all queried tables until we offset back to the first table."""
         at_last_page = False
         incidents = dict()

--- a/incident_scraper/utils/constants.py
+++ b/incident_scraper/utils/constants.py
@@ -1,13 +1,21 @@
 """Contains constants that are used throughout the application."""
 
+# Date/Time Constants
 TIMEZONE_CHICAGO = "America/Chicago"
+
+# File Constants
+FILE_OPEN_MODE_READ = "r"
+
+# Scraping Constants
 HEADERS = {
-    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7",
+    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,"
+    "image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7",
     "Accept-Encoding": "gzip, deflate, br",
     "Accept-Language": "en-US,en;q=0.9",
     "Cache-Control": "max-age=0",
     "Connection": "keep-alive",
     "Host": "incidentreports.uchicago.edu",
     "Upgrade-Insecure-Requests": "1",
-    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36",
+    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 ("
+    "HTML, like Gecko) Chrome/114.0.0.0 Safari/537.36",
 }

--- a/incident_scraper/utils/constants.py
+++ b/incident_scraper/utils/constants.py
@@ -1,3 +1,13 @@
 """Contains constants that are used throughout the application."""
 
 TIMEZONE_CHICAGO = "America/Chicago"
+HEADERS = {
+    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7",
+    "Accept-Encoding": "gzip, deflate, br",
+    "Accept-Language": "en-US,en;q=0.9",
+    "Cache-Control": "max-age=0",
+    "Connection": "keep-alive",
+    "Host": "incidentreports.uchicago.edu",
+    "Upgrade-Insecure-Requests": "1",
+    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36",
+}


### PR DESCRIPTION
## Describe your changes
- Removing the epoch conversion features
- User is now able to scrape -x- days back
- Rotating user agents now works

## Checklist before requesting a review
- [x] The code runs successfully.

```
% make three_days
python -m incident_scraper days-back 3
Today's date: 2023-07-19
Constructing URL...
Fetching https://incidentreports.uchicago.edu/incidentReportArchive.php?startDate=07/16/2023&endDate=07/19/2023&offset=0
Fetching https://incidentreports.uchicago.edu/incidentReportArchive.php?startDate=07/16/2023&endDate=07/19/2023&offset=5
Fetching https://incidentreports.uchicago.edu/incidentReportArchive.php?startDate=07/16/2023&endDate=07/19/2023&offset=10
Fetching https://incidentreports.uchicago.edu/incidentReportArchive.php?startDate=07/16/2023&endDate=07/19/2023&offset=15
Fetching https://incidentreports.uchicago.edu/incidentReportArchive.php?startDate=07/16/2023&endDate=07/19/2023&offset=20
We scraped this many incidents: 22
% 
```
