### PR TITLE
Update `download-and-move` command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,9 @@ download:
 
 .PHONY: download-and-move
 download-and-move: download
-	mv ./incident_dump.csv ../one-offs/notebooks/data/
+	cp ./incident_dump.csv ../one-offs/notebooks/data/
+	gzip ./incident_dump.csv
+	mv ./incident_dump.csv.gz ../ucpd-incident-reporting/incident_reporting/
 
 .PHONY: seed
 seed:


### PR DESCRIPTION
## Describe your changes
Updated the `download-and-move` so that it moves a gzipped version of the incidents to the UCPD Incident Reporter.

## Checklist before requesting a review
- [x] The code runs successfully.

```commandline
(ucpd-incident-scraper-py3.11) michaelp@MacBook-Air-5 ucpd-incident-scraper % make download-and-move
python -m incident_scraper download
Downloaded 11183 incident records.
Saved 11183 incident records to a CSV.
Program shutting down, attempting to send 1 queued log entries to Cloud Logging...
Waiting up to 5 seconds.
Sent all pending logs.
cp ./incident_dump.csv ../one-offs/notebooks/data/
gzip ./incident_dump.csv
mv ./incident_dump.csv.gz ../ucpd-incident-reporting/incident_reporting/
(ucpd-incident-scraper-py3.11) michaelp@MacBook-Air-5 ucpd-incident-scraper % 
```
