### PR TITLE
Add address string cleaning functionality

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,6 +43,14 @@ repos:
           - --profile=black
           - --line-length=80
 
+  - repo: https://github.com/psf/black
+    rev: 23.7.0
+    hooks:
+      - id: black
+        args:
+          - --target-version=py311
+          - --line-length=80
+
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.0.286
     hooks:
@@ -61,11 +69,3 @@ repos:
         args:
           - --ignore=E203,E402,E501,E800,W503,W391,E261
           - --select=B,C,E,F,W,T4,B9
-
-  - repo: https://github.com/psf/black
-    rev: 23.7.0
-    hooks:
-      - id: black
-        args:
-          - --target-version=py311
-          - --line-length=80

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,13 @@
 BASEDIR=incident_scraper
 
-default: create-requirements lint
+default: create_requirements lint
 
 .PHONY: lint
 lint:
 	pre-commit run --all-files
 
-.PHONY: create-requirements
-create-requirements:
+.PHONY: create_requirements
+create_requirements:
 	poetry export --without-hashes --format=requirements.txt > requirements.txt
 
 .PHONY: download
@@ -28,12 +28,16 @@ build_model: download
 categorize:
 	python -m incident_scraper categorize
 
-.PHONY: correct-geopt
-correct-geopt:
+.PHONY: correct_geopt
+correct_geopt:
 	python -m incident_scraper correct-geopt
 
-.PHONY: lemmatize-categories
-lemmatize-categories:
+.PHONY: correct_location
+correct_location:
+	python -m incident_scraper correct-location
+
+.PHONY: lemmatize_categories
+lemmatize_categories:
 	python -m incident_scraper lemmatize-categories
 
 .PHONY: seed
@@ -67,7 +71,3 @@ thirty_days:
 .PHONY: test
 test:
 	pytest -vs test/
-
-.PHONY: test-and-fail
-test-and-fail:
-	pytest -vsx test/

--- a/incident_scraper/__main__.py
+++ b/incident_scraper/__main__.py
@@ -198,6 +198,7 @@ def parse_and_save_records(
                 continue
 
             i[INCIDENT_KEY_ID] = key
+
             i[INCIDENT_KEY_LOCATION] = i[INCIDENT_KEY_LOCATION].replace(
                 "&", "and"
             )

--- a/incident_scraper/__main__.py
+++ b/incident_scraper/__main__.py
@@ -198,11 +198,14 @@ def parse_and_save_records(
                 continue
 
             i[INCIDENT_KEY_ID] = key
+            i[INCIDENT_KEY_LOCATION] = i[INCIDENT_KEY_LOCATION].replace(
+                "&", "and"
+            )
             address = (
                 i[INCIDENT_KEY_LOCATION].split(" (")[0]
                 if "(" in i[INCIDENT_KEY_LOCATION]
                 else i[INCIDENT_KEY_LOCATION]
-            ).replace("&", "and")
+            )
 
             i[INCIDENT_KEY_REPORTED] = i[INCIDENT_KEY_REPORTED].replace(
                 ";", ":"

--- a/incident_scraper/external/geocoder.py
+++ b/incident_scraper/external/geocoder.py
@@ -40,6 +40,7 @@ class Geocoder:
             and "between" not in address
             and " and " not in address
             and " to " not in address
+            and " at " not in address
         ):
             self._get_address_from_cache(
                 i_dict, self._get_address_from_census(address)

--- a/incident_scraper/external/geocoder.py
+++ b/incident_scraper/external/geocoder.py
@@ -22,6 +22,9 @@ class Geocoder:
     A class that houses code for both the Census and Google Maps geocoders.
     """
 
+    # Approximate bounding box of UCPD patrol area:
+    # https://d3qi0qp55mx5f5.cloudfront.net/safety-security/uploads/files/Extended_Patrol_Map.pdf
+    BOUNDING_BOX = [-87.608703, 41.776408, -87.568594, 41.826281]
     NUM_RETRIES = 10
     TIMEOUT = 5
 

--- a/incident_scraper/external/geocoder.py
+++ b/incident_scraper/external/geocoder.py
@@ -23,9 +23,6 @@ class Geocoder:
     A class that houses code for both the Census and Google Maps geocoders.
     """
 
-    # Approximate bounding box of UCPD patrol area:
-    # https://d3qi0qp55mx5f5.cloudfront.net/safety-security/uploads/files/Extended_Patrol_Map.pdf
-    BOUNDING_BOX = [-87.608703, 41.776408, -87.568594, 41.826281]
     NUM_RETRIES = 10
     TIMEOUT = 5
 

--- a/incident_scraper/external/geocoder.py
+++ b/incident_scraper/external/geocoder.py
@@ -12,6 +12,7 @@ from incident_scraper.utils.constants import (
     INCIDENT_KEY_LATITUDE,
     INCIDENT_KEY_LONGITUDE,
     LOCATION_CHICAGO,
+    LOCATION_HYDE_PARK,
     LOCATION_ILLINOIS,
     LOCATION_US,
 )
@@ -102,7 +103,7 @@ class Geocoder:
             [address],
             # Enable Coding Accuracy Support System
             enableUspsCass=True,
-            locality=LOCATION_CHICAGO,
+            locality=LOCATION_HYDE_PARK,
             regionCode=LOCATION_US,
         )
 

--- a/incident_scraper/external/geocoder.py
+++ b/incident_scraper/external/geocoder.py
@@ -42,6 +42,7 @@ class Geocoder:
             INCIDENT_KEY_ADDRESS not in i_dict
             and "between" not in address
             and " and " not in address
+            and " to " not in address
         ):
             self._get_address_from_cache(
                 i_dict, self._get_address_from_census(address)

--- a/incident_scraper/utils/constants.py
+++ b/incident_scraper/utils/constants.py
@@ -58,6 +58,7 @@ class SystemFlags:
     BUILD_MODEL = "build-model"
     CATEGORIZE = "categorize"
     CORRECT_GEOPT = "correct-geopt"
+    CORRECT_LOCATION = "correct-location"
     DAYS_BACK = "days-back"
     DOWNLOAD = "download"
     LEMMATIZE_CATEGORIES = "lemmatize-categories"

--- a/incident_scraper/utils/constants.py
+++ b/incident_scraper/utils/constants.py
@@ -46,6 +46,7 @@ INCIDENT_TYPE_INFO = "Information"
 
 # Location Constants
 LOCATION_CHICAGO = "Chicago"
+LOCATION_HYDE_PARK = "Hyde Park, Chicago"
 LOCATION_ILLINOIS = "IL"
 LOCATION_US = "US"
 TIMEZONE_KEY_CHICAGO = f"America/{LOCATION_CHICAGO}"

--- a/incident_scraper/utils/functions.py
+++ b/incident_scraper/utils/functions.py
@@ -47,6 +47,8 @@ def address_correction(address: str) -> str:
         .replace(" .s ", " .S ")
         .replace(" .e ", " .E ")
         .replace(" st. ", " St. ")
+        .replace(" pl. ", " Pl. ")
+        .replace(" Midway Pl. ", " Midway Plaisance ")
     )
 
     address = re.sub(r"\s{2,}", " ", address)

--- a/incident_scraper/utils/functions.py
+++ b/incident_scraper/utils/functions.py
@@ -33,6 +33,7 @@ STREET_CORRECTIONS = [
     create_street_tuple("Kimbark"),
     create_street_tuple("Lake Park"),
     create_street_tuple("Maryland"),
+    create_street_tuple("Oakenwald"),
     create_street_tuple("Oakwood", blvd=True),
     create_street_tuple("Stony Island"),
     create_street_tuple("University"),
@@ -52,13 +53,17 @@ def address_correction(address: str) -> str:
 
     numerical_streets = [make_ordinal(s) for s in range(37, 66)]
     for s in numerical_streets:
-        fmt_s = f"E. {s}"
-        if s in address and fmt_s not in address:
-            address = address.replace(s, fmt_s)
+        dir_s = f"E. {s}"
+        if s in address and dir_s not in address:
+            address = address.replace(s, dir_s)
 
-        fmt_s += " St."
-        if s in address and fmt_s not in address and f"{s} Pl" not in address:
-            address = address.replace(s, fmt_s)
+        full_s = f"{dir_s} St."
+        if (
+            dir_s in address
+            and full_s not in address
+            and f"{s} Pl" not in address
+        ):
+            address = address.replace(dir_s, full_s)
 
     for sc in STREET_CORRECTIONS:
         name, dir_name, full_name = sc

--- a/incident_scraper/utils/functions.py
+++ b/incident_scraper/utils/functions.py
@@ -1,11 +1,75 @@
 import re
 from datetime import datetime
-from typing import Optional
+from typing import Optional, Tuple
 
 from incident_scraper.utils.constants import (
     INCIDENT_KEY_REPORTED,
     UCPD_DATE_FORMATS,
 )
+
+
+def create_street_tuple(
+    street: str, blvd: bool = False
+) -> Tuple[str, str, str]:
+    street_type = "Ave." if not blvd else "Blvd."
+
+    return street, f"S. {street}", f"S. {street} {street_type}"
+
+
+STREET_CORRECTIONS = [
+    create_street_tuple("Blackstone"),
+    create_street_tuple("Cottage Grove"),
+    create_street_tuple("Cornell"),
+    create_street_tuple("Dorchester"),
+    create_street_tuple("Drexel"),
+    create_street_tuple("East End"),
+    create_street_tuple("Ellis"),
+    create_street_tuple("Everett"),
+    create_street_tuple("Greenwood"),
+    create_street_tuple("Harper"),
+    create_street_tuple("Hyde Park", blvd=True),
+    create_street_tuple("Ingleside"),
+    create_street_tuple("Kenwood"),
+    create_street_tuple("Kimbark"),
+    create_street_tuple("Lake Park"),
+    create_street_tuple("Maryland"),
+    create_street_tuple("Oakwood", blvd=True),
+    create_street_tuple("Stony Island"),
+    create_street_tuple("University"),
+    create_street_tuple("Woodlawn"),
+]
+
+
+def address_correction(address: str) -> str:
+    address = (
+        address.replace("&", "and")
+        .replace(" .s ", " .S ")
+        .replace(" .e ", " .E ")
+        .replace(" st. ", " St. ")
+    )
+
+    address = re.sub(r"\s{2,}", " ", address)
+
+    numerical_streets = [make_ordinal(s) for s in range(37, 66)]
+    for s in numerical_streets:
+        fmt_s = f"E. {s}"
+        if s in address and fmt_s not in address:
+            address = address.replace(s, fmt_s)
+
+        fmt_s += " St."
+        if s in address and fmt_s not in address and f"{s} Pl" not in address:
+            address = address.replace(s, fmt_s)
+
+    for sc in STREET_CORRECTIONS:
+        name, dir_name, full_name = sc
+
+        if name in address and dir_name not in address:
+            address = address.replace(name, dir_name)
+
+        if dir_name in address and full_name not in address:
+            address = address.replace(dir_name, full_name)
+
+    return address
 
 
 # Source: https://www.geeksforgeeks.org/convert-string-to-title-case-in-python/
@@ -64,6 +128,23 @@ def custom_title_case(input_string: str) -> str:
             output_list.append(word.title())
 
     return " ".join(output_list)
+
+
+# Source: https://stackoverflow.com/a/50992575
+def make_ordinal(n: int):
+    """
+    Convert an integer into its ordinal representation::
+
+        make_ordinal(0)   => '0th'
+        make_ordinal(3)   => '3rd'
+        make_ordinal(122) => '122nd'
+        make_ordinal(213) => '213th'
+    """
+    if 11 <= (n % 100) <= 13:
+        suffix = "th"
+    else:
+        suffix = ["th", "st", "nd", "rd", "th"][min(n % 10, 4)]
+    return str(n) + suffix
 
 
 def parse_scraped_incident_timestamp(i: dict) -> Optional[str]:


### PR DESCRIPTION
## Describe your changes
Added an `address_correction` function that clears up a lot of ambiguities for address searching. I still haven't been able to get the cross street problem fixed, but I'm gonna save that for a later time.


## Checklist before requesting a review
- [x] The code runs successfully.

```commandline
(ucpd-incident-scraper-py3.11) michaelp@MacBook-Air-18 ucpd-incident-scraper % make correct_location                                                                        
python -m incident_scraper correct-location
[nltk_data] Downloading package wordnet to
[nltk_data]     /Users/michaelp/nltk_data...
[nltk_data]   Package wordnet is already up-to-date!
API queries_quota: 60
1425 E. Midway Pl. (Public Way) changed to 1425 E. Midway Plaisance (Public Way)
1130 E. Midway Pl. (Park District Skating Rink) changed to 1130 E. Midway Plaisance (Park District Skating Rink)
819 E. Midway Pl. (Public Way) changed to 819 E. Midway Plaisance (Public Way)
...
Area of Midway Pl. and S. Ellis Ave. changed to Area of Midway Plaisance and S. Ellis Ave.
1111 E. Midway Pl. (Winter Garden) changed to 1111 E. Midway Plaisance (Winter Garden)
1005 E. Midway Pl. (Park Dist. Property) changed to 1005 E. Midway Plaisance (Park Dist. Property)
1130 E. Midway Pl. (Skating Rink) changed to 1130 E. Midway Plaisance (Skating Rink)
78 of 16819 had their address updated.
78 addresses were updated.
Waiting up to 5 seconds.
Sent all pending logs.
```
