### PR TITLE
Add warning for bad date differentials

### DIFF
--- a/incident_scraper/__main__.py
+++ b/incident_scraper/__main__.py
@@ -90,7 +90,9 @@ def main():  # noqa: C901
             if day_diff > 0:
                 incidents = scraper.scrape_last_days(day_diff - 1)
             else:
-                logging.info("Saved incidents are up-to-date.")
+                logging.warning(
+                    f"Scraper did not add any new incidents for {datetime.now().date()} with a day diff of {day_diff}"
+                )
 
     if len(incidents.keys()):
         parse_and_save_records(incidents, nbd_client)

--- a/incident_scraper/__main__.py
+++ b/incident_scraper/__main__.py
@@ -84,14 +84,14 @@ def main():  # noqa: C901
         case SystemFlags.SEED:
             incidents = scraper.scrape_from_beginning_2011()
         case SystemFlags.UPDATE:
-            day_diff = (
-                datetime.now().date() - nbd_client.get_latest_date()
-            ).days
+            now = datetime.now().date()
+            day_diff = (now - nbd_client.get_latest_date()).days
             if day_diff > 0:
                 incidents = scraper.scrape_last_days(day_diff - 1)
-            else:
+            elif now.isoweekday() not in (6, 7):
+                # Use the warning log level if day_diff <= 0, and it's a weekday
                 logging.warning(
-                    f"Scraper did not add any new incidents for {datetime.now().date()} with a day diff of {day_diff}"
+                    f"Scraper did not add any new incidents for {now} with a day diff of {day_diff}"
                 )
 
     if len(incidents.keys()):


### PR DESCRIPTION
## Describe your changes
Added a warning level log for situations like the one below where the date differential between the latest incident and the current day is below 0.

![image](https://github.com/user-attachments/assets/1b45dcb2-c676-4eeb-8451-cdc6b0c85de3)

## Checklist before requesting a review
- [x] The code runs successfully.

```commandline
(ucpd-incident-scraper-py3.11) michaelp@MacBook-Air-18 ucpd-incident-scraper % make update
python -m incident_scraper update
[nltk_data] Downloading package wordnet to
[nltk_data]     /Users/michaelp/nltk_data...
[nltk_data]   Package wordnet is already up-to-date!
Beginning the UCPD Incident scraping process.
WARNING: All log messages before absl::InitializeLog() is called are written to STDERR
I0000 00:00:1730234441.781748  990136 check_gcp_environment_no_op.cc:29] ALTS: Platforms other than Linux and Windows are not supported
Finished with the UCPD Incident scraping process.
Waiting up to 5 seconds.
Sent all pending logs.
(ucpd-incident-scraper-py3.11) michaelp@MacBook-Air-18 ucpd-incident-scraper %
```
